### PR TITLE
Fix duplicate shortlink creation

### DIFF
--- a/shortlink_manager.module
+++ b/shortlink_manager.module
@@ -368,6 +368,12 @@ function shortlink_manager_entity_insert(EntityInterface $entity): void {
     }
   }
 
+  // Record that shortlinks were just created for this entity so that
+  // hook_entity_update() can skip re-creation if another module calls
+  // $entity->save() during the same hook_entity_insert() invocation.
+  $recently_inserted = &drupal_static('shortlink_manager_recently_inserted', []);
+  $recently_inserted[$entity->getEntityTypeId() . ':' . $entity->id()] = TRUE;
+
 }
 
 function shortlink_manager_entity_delete(EntityInterface $entity): void {
@@ -385,6 +391,16 @@ function shortlink_manager_entity_update(EntityInterface $entity): void {
   // Only operate on content entities.
   if (!($entity instanceof ContentEntityBase)) {
     \Drupal::logger('shortlink_manager')->notice('Entity is not instance of ContentEntityBase.');
+    return;
+  }
+
+  // If shortlinks were just created for this entity during hook_entity_insert()
+  // in this same request, skip processing here. This prevents duplicate
+  // shortlinks when another module calls $entity->save() inside its own
+  // hook_entity_insert() implementation, which triggers hook_entity_update()
+  // before the entity query cache reflects the newly created shortlinks.
+  $recently_inserted = &drupal_static('shortlink_manager_recently_inserted', []);
+  if (isset($recently_inserted[$entity->getEntityTypeId() . ':' . $entity->id()])) {
     return;
   }
 


### PR DESCRIPTION
Fix duplicate shortlink creation when entity_update fires after entity_insert

When another module calls \$entity->save() inside hook_entity_insert(), Drupal fires hook_entity_update() before the entity query cache reflects the newly created shortlinks. This caused loadByProperties() to return empty results, making all configured UTM sets appear new and creating duplicate shortlinks.

Uses drupal_static() to record entities processed by hook_entity_insert() and bail early in hook_entity_update() if the entity was just inserted this request.